### PR TITLE
Fixes issue with barrel azimuth @ 90deg

### DIFF
--- a/BallisticCalculator.Test/Calculator/TrajectoryCalculatorTest.cs
+++ b/BallisticCalculator.Test/Calculator/TrajectoryCalculatorTest.cs
@@ -109,6 +109,32 @@ namespace BallisticCalculator.Test.Calculator
         }
 
         [Fact]
+        public void TrajectoryTest_Azimuth90Degrees()
+        {
+            TableLoader template = TableLoader.FromResource("g1_nowind");
+
+            var cal = new TrajectoryCalculator();
+
+            ShotParameters shot = new ShotParameters()
+            {
+                Step = new Measurement<DistanceUnit>(50, DistanceUnit.Yard),
+                MaximumDistance = new Measurement<DistanceUnit>(1000, DistanceUnit.Yard),
+                SightAngle = cal.SightAngle(template.Ammunition, template.Rifle, template.Atmosphere),
+                ShotAngle = template.ShotParameters?.ShotAngle,
+                CantAngle = template.ShotParameters?.CantAngle,
+                BarrelAzimuth = new Measurement<AngularUnit>(90, AngularUnit.Degree)
+            };
+
+            var winds = template.Wind == null ? null : new Wind[] { template.Wind };
+
+            var trajectory = cal.Calculate(template.Ammunition, template.Rifle, template.Atmosphere, shot, winds);
+
+            trajectory.Length.Should().BeGreaterThan(1, "Trajectory should have multiple points even at azimuth 90°");
+            trajectory.Should().NotContain(p => p == null, "All trajectory points should be valid");
+            trajectory.Last().Distance.In(DistanceUnit.Yard).Should().BeGreaterThan(900, "Trajectory should progress to near maximum distance");
+        }
+
+        [Fact]
         public void CustomTable()
         {
             TableLoader template = TableLoader.FromResource("g1_nowind");

--- a/BallisticCalculator/Calculations/TrajectoryCalculator.cs
+++ b/BallisticCalculator/Calculations/TrajectoryCalculator.cs
@@ -341,7 +341,10 @@ namespace BallisticCalculator
                         break;
                 }
                 
-                var deltaTime = BallisticMath.TravelTime(calculationStep, velocityVector.X);
+                var horizontalVelocity = new Vector<VelocityUnit>(velocityVector.X, new Measurement<VelocityUnit>(0, velocityVector.X.Unit), velocityVector.Z).Magnitude;
+                if (horizontalVelocity.Value < 0.001)
+                    horizontalVelocity = new Measurement<VelocityUnit>(0.001, horizontalVelocity.Unit);
+                var deltaTime = BallisticMath.TravelTime(calculationStep, horizontalVelocity);
                 var velocityAdjusted = velocityVector - windVector;
 
                 velocity = velocityAdjusted.Magnitude;
@@ -370,7 +373,7 @@ namespace BallisticCalculator
                         new Measurement<DistanceUnit>(velocityVector.Z.In(VelocityUnit.MetersPerSecond) * deltaTime.TotalSeconds, DistanceUnit.Meter));
 
                 rangeVector += deltaRangeVector;
-                distance = rangeVector.X / lineOfSightCos;
+                distance = new Vector<DistanceUnit>(rangeVector.X, new Measurement<DistanceUnit>(0, rangeVector.X.Unit), rangeVector.Z).Magnitude / lineOfSightCos;
                 alt += deltaRangeVector.Y;
                 velocity = velocityVector.Magnitude;
                 time = time.Add(BallisticMath.TravelTime(deltaRangeVector.Magnitude, velocity));


### PR DESCRIPTION
Hi! This fix is for a trajectory calculation failure at azimuth 90° (shooting East). The effect was that you ended up with a sequence of `TrajectoryPoint[]` where only the first value existed (all others being `null`).

When `BarrelAzimuth` was set to 90° `velocityVector.X` becomes 0 because:
- `velocityVector.X = velocity * cos(elevation) * cos(90°) = velocity * cos(elevation) * 0 = 0`

This caused two problems:
1. **Time calculation**: `BallisticMath.TravelTime(calculationStep, velocityVector.X)` would divide by zero when `velocityVector.X` was 0
2. **Distance calculation**: `distance = rangeVector.X / lineOfSightCos` would stay at 0 because `rangeVector.X` didn't increase, causing the trajectory loop to never emit trajectory points beyond the first one.

For example:

Set `BarrelAzimuth` to 90deg in `ShotParameters`:

```csharp
var shot = new ShotParameters()
{
    // ... other parameters ...
    BarrelAzimuth = new Measurement<AngularUnit>(90, AngularUnit.Degree)
};
var trajectory = calculator.Calculate(ammunition, rifle, atmosphere, shot);
// Result: trajectory array contains only 1 point or fails to progress
```

Fixed by using the horizontal velocity/range magnitude instead of just the X component:

1. **Time calculation**: Calculate horizontal velocity magnitude using `Vector.Magnitude` on `(velocityVector.X, 0, velocityVector.Z)`, which works correctly even when X is 0.

2. **Distance calculation**: Calculate horizontal range magnitude using `Vector.Magnitude` on `(rangeVector.X, 0, rangeVector.Z)`, so distance progresses correctly even at azimuth 90°.

Added regression test `TrajectoryTest_Azimuth90Degrees` that verifies:
- Trajectory completes successfully at azimuth 90°
- Multiple trajectory points are generated
- All points are valid (not null)
- Trajectory progresses to near maximum distance