### PR TITLE
Incorporate the Coriolis effect

### DIFF
--- a/BallisticCalculator.Test/Calculator/TrajectoryCalculatorTest.cs
+++ b/BallisticCalculator.Test/Calculator/TrajectoryCalculatorTest.cs
@@ -298,5 +298,115 @@ namespace BallisticCalculator.Test.Calculator
                 }
             }
         }
+
+        [Fact]
+        public void Supports90DegreesAzimuth()
+        {
+            var template = TableLoader.FromResource("g1_nowind");
+
+            var cal = new TrajectoryCalculator();
+
+            ShotParameters shot = new ShotParameters()
+            {
+                Step = new Measurement<DistanceUnit>(50, DistanceUnit.Yard),
+                MaximumDistance = new Measurement<DistanceUnit>(1000, DistanceUnit.Yard),
+                SightAngle = cal.SightAngle(template.Ammunition, template.Rifle, template.Atmosphere),
+                ShotAngle = template.ShotParameters?.ShotAngle,
+                CantAngle = template.ShotParameters?.CantAngle,
+                BarrelAzimuth = new Measurement<AngularUnit>(90, AngularUnit.Degree),
+            };
+
+            var winds = template.Wind == null ? null : new Wind[] { template.Wind };
+            var trajectory = cal.Calculate(template.Ammunition, template.Rifle, template.Atmosphere, shot, winds);
+
+            trajectory.Length.Should().BeGreaterThan(1, "Trajectory should have multiple points even at azimuth 90°");
+
+            foreach (var point in trajectory)
+            {
+                point.Should().NotBeNull("Trajectory point should be valid");
+            }
+
+            trajectory[trajectory.Length - 1].Distance.In(DistanceUnit.Yard).Should().BeGreaterThan(900, "Trajectory should progress to near maximum distance");
+        }
+
+        [Theory]
+        [InlineData(45, 0, -1.03, -222.52)]     // 45° latitude, 0° azimuth (north) - original test case
+        [InlineData(0, 0, 0.0, -222.52)]        // 0° latitude (equator), 0° azimuth (north) - minimal Coriolis
+        [InlineData(90, 0, -1.46, -222.52)]     // 90° latitude (pole), 0° azimuth (north) - maximum Coriolis
+        [InlineData(45, 90, -1.03, -220.64)]    // 45° latitude, 90° azimuth (east) - Eötvös reduces drop
+        [InlineData(45, 180, -1.03, -222.52)]    // 45° latitude, 180° azimuth (south) - opposite windage
+        [InlineData(45, 270, -1.03, -224.40)]   // 45° latitude, 270° azimuth (west) - Eötvös increases drop
+        [InlineData(30, 0, -0.73, -222.52)]     // 30° latitude, 0° azimuth (north)
+        [InlineData(60, 0, -1.27, -222.52)]     // 60° latitude, 0° azimuth (north)
+        [InlineData(-45, 0, 1.03, -222.52)]     // 45°S latitude, 0° azimuth (north) - deflects left/West
+        [InlineData(-45, 90, 1.03, -220.64)]    // 45°S latitude, 90° azimuth (east) - Eötvös increases drop
+        [InlineData(-45, 180, 1.03, -222.52)]  // 45°S latitude, 180° azimuth (south) - deflects left/East
+        [InlineData(-45, 270, 1.03, -224.40)]   // 45°S latitude, 270° azimuth (west) - Eötvös reduces drop
+        public void CoriolisDeflectionAt2000Yd(int latitudeDeg, int azimuthDeg, double expectedWindageMOA, double expectedElevationMOA)
+        {
+            Ammunition ammunition = new Ammunition(
+                weight: new Measurement<WeightUnit>(69, WeightUnit.Grain),
+                muzzleVelocity: new Measurement<VelocityUnit>(2600, VelocityUnit.FeetPerSecond),
+                ballisticCoefficient: new BallisticCoefficient(0.365, DragTableId.G1)
+            );
+
+            // Standard rifle setup
+            Rifle rifle = new Rifle(
+                sight: new Sight(sightHeight: new Measurement<DistanceUnit>(3.2, DistanceUnit.Inch), Measurement<AngularUnit>.ZERO, Measurement<AngularUnit>.ZERO),
+                zero: new ZeroingParameters(distance: new Measurement<DistanceUnit>(100, DistanceUnit.Yard), ammunition: null, atmosphere: null)
+            );
+
+            Atmosphere atmosphere = new Atmosphere(
+                altitude: new Measurement<DistanceUnit>(0, DistanceUnit.Meter),
+                pressure: new Measurement<PressureUnit>(29.92, PressureUnit.InchesOfMercury),
+                humidity: 0,
+                temperature: new Measurement<TemperatureUnit>(59, TemperatureUnit.Fahrenheit)
+            );
+
+            ShotParameters shot = new ShotParameters();
+            shot.Step = new Measurement<DistanceUnit>(1, DistanceUnit.Yard);
+            shot.MaximumDistance = new Measurement<DistanceUnit>(2000, DistanceUnit.Yard); // Match app's maximumDistance
+            shot.Latitude = new Measurement<AngularUnit>(latitudeDeg, AngularUnit.Degree);
+            shot.BarrelAzimuth = new Measurement<AngularUnit>(azimuthDeg, AngularUnit.Degree);
+            shot.ShotAngle = new Measurement<AngularUnit>(0, AngularUnit.Radian); // Explicitly set to 0 to match app defaults
+
+            var cal = new TrajectoryCalculator();
+            shot.SightAngle = cal.SightAngle(ammunition, rifle, atmosphere);
+
+            var trajectory = cal.Calculate(
+                ammunition,
+                rifle,
+                atmosphere,
+                shot,
+                null // No wind
+            );
+
+            var targetDistance = new Measurement<DistanceUnit>(2000, DistanceUnit.Yard);
+            TrajectoryPoint closestPoint = null;
+            double minDiff = double.MaxValue;
+
+            foreach (var point in trajectory)
+            {
+                var pointDistance = point.Distance.To(targetDistance.Unit);
+                var diff = Math.Abs(pointDistance.Value - targetDistance.Value);
+
+                if (diff < minDiff && diff < 0.5)
+                {
+                    minDiff = diff;
+                    closestPoint = point;
+                }
+            }
+
+            closestPoint.Should().NotBeNull("Should find a trajectory point within 0.5 yards of 2000 yards");
+
+            double actualWindageMOA = closestPoint.WindageAdjustment.In(AngularUnit.MOA);
+            double actualElevationMOA = closestPoint.DropAdjustment.In(AngularUnit.MOA);
+
+            actualWindageMOA.Should().BeApproximately(expectedWindageMOA, 0.5, 
+                $"Windage at 2000yd should be {expectedWindageMOA} MOA for latitude {latitudeDeg}°, azimuth {azimuthDeg}°");
+
+            actualElevationMOA.Should().BeApproximately(expectedElevationMOA, 0.5, 
+                $"Elevation at 2000yd should be {expectedElevationMOA} MOA for latitude {latitudeDeg}°, azimuth {azimuthDeg}°");
+        }
     }
 }

--- a/BallisticCalculator/Calculations/ShotParameters.cs
+++ b/BallisticCalculator/Calculations/ShotParameters.cs
@@ -55,5 +55,12 @@ namespace BallisticCalculator
         /// </summary>
         [BXmlProperty("maximum-distance")]
         public Measurement<DistanceUnit> MaximumDistance { get; set; }
+
+        /// <summary>
+        /// Latitude angle for Coriolis effect calculation
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [BXmlProperty("latitude", Optional = true)]
+        public Measurement<AngularUnit>? Latitude { get; set; }
     }
 }

--- a/BallisticCalculator/Calculations/TrajectoryCalculator.cs
+++ b/BallisticCalculator/Calculations/TrajectoryCalculator.cs
@@ -32,6 +32,11 @@ namespace BallisticCalculator
         /// </summary>
         private const double PIR = 2.08551e-04;
 
+        /// <summary>
+        /// Earth's angular velocity in radians per second
+        /// </summary>
+        private const double EARTH_ANGULAR_VELOCITY = 7.292115e-5;
+
         private static DragTable ValidateDragTable(Ammunition ammunition, DragTable dragTable)
         {
             if (ammunition.BallisticCoefficient.Table == DragTableId.GC)
@@ -293,6 +298,14 @@ namespace BallisticCalculator
                 {
                     var windage = rangeVector.Z;
                     
+                    // Convert from global (North, East) to local perpendicular component when latitude is set
+                    if (shot.Latitude != null)
+                    {
+                        double sinAz = MeasurementMath.Sin(barrelAzimuth);
+                        double cosAz = MeasurementMath.Cos(barrelAzimuth);
+                        windage = rangeVector.X * sinAz - rangeVector.Z * cosAz;
+                    }
+                    
                     if (calculateDrift)
                         windage += new Measurement<DistanceUnit>(1.25 * (stabilityCoefficient + 1.2) * Math.Pow(time.TotalSeconds, 1.83) * (rifle.Rifling.Direction == TwistDirection.Right ? -1 : 1), DistanceUnit.Inch);
 
@@ -341,7 +354,17 @@ namespace BallisticCalculator
                         break;
                 }
                 
-                var deltaTime = BallisticMath.TravelTime(calculationStep, velocityVector.X);
+                // Calculate horizontal velocity for deltaTime calculation
+                var horizontalVelocity = new Vector<VelocityUnit>(
+                    velocityVector.X,
+                    new Measurement<VelocityUnit>(0, velocityVector.X.Unit),
+                    velocityVector.Z
+                ).Magnitude;
+
+                if (horizontalVelocity.Value < 0.001)
+                    horizontalVelocity = new Measurement<VelocityUnit>(0.001, horizontalVelocity.Unit);
+
+                var deltaTime = BallisticMath.TravelTime(calculationStep, horizontalVelocity);
                 var velocityAdjusted = velocityVector - windVector;
 
                 velocity = velocityAdjusted.Magnitude;
@@ -357,6 +380,7 @@ namespace BallisticCalculator
                 drag = accumulatedFactor * densityFactor * dragTableNode.CalculateDrag(currentMach) * velocity.Value;
                 var factor = deltaTime.TotalSeconds * drag;
 
+                var velocityVectorBefore = velocityVector;
                 velocityVector = new Vector<VelocityUnit>(
                     velocityVector.X - factor * velocityAdjusted.X,
                     velocityVector.Y - factor * velocityAdjusted.Y
@@ -369,8 +393,23 @@ namespace BallisticCalculator
                         new Measurement<DistanceUnit>(velocityVector.Y.In(VelocityUnit.MetersPerSecond) * deltaTime.TotalSeconds, DistanceUnit.Meter),
                         new Measurement<DistanceUnit>(velocityVector.Z.In(VelocityUnit.MetersPerSecond) * deltaTime.TotalSeconds, DistanceUnit.Meter));
 
+                // Add Coriolis deflection if latitude is specified
+                if (shot.Latitude != null)
+                {
+                    var coriolisDeflection = CalculateCoriolisDeflection(
+                        shot.Latitude.Value,
+                        barrelAzimuth,
+                        time,
+                        time.Add(deltaTime),
+                        velocityVectorBefore,
+                        velocityVector);
+                    deltaRangeVector += coriolisDeflection;
+                }
+
                 rangeVector += deltaRangeVector;
-                distance = rangeVector.X / lineOfSightCos;
+                // Update distance calculation to use horizontal velocity component
+                var horizontalRangeVector = new Vector<DistanceUnit>(rangeVector.X, new Measurement<DistanceUnit>(0, rangeVector.X.Unit), rangeVector.Z);
+                distance = horizontalRangeVector.Magnitude / lineOfSightCos;
                 alt += deltaRangeVector.Y;
                 velocity = velocityVector.Magnitude;
                 time = time.Add(BallisticMath.TravelTime(deltaRangeVector.Magnitude, velocity));
@@ -439,6 +478,60 @@ namespace BallisticCalculator
                 ftp = ((ft + 460) / (59 + 460)) * (29.92 / pt);
             }
             return sd * fv * ftp;
+        }
+
+        private static Vector<DistanceUnit> CalculateCoriolisDeflection(
+            Measurement<AngularUnit> latitude,
+            Measurement<AngularUnit> azimuth,
+            TimeSpan timeStart,
+            TimeSpan timeEnd,
+            Vector<VelocityUnit> velocityVectorStart,
+            Vector<VelocityUnit> velocityVectorEnd)
+        {
+            if (timeStart >= timeEnd)
+            {
+                return new Vector<DistanceUnit>(
+                    new Measurement<DistanceUnit>(0, DistanceUnit.Meter),
+                    new Measurement<DistanceUnit>(0, DistanceUnit.Meter),
+                    new Measurement<DistanceUnit>(0, DistanceUnit.Meter));
+            }
+
+            double sinLat = MeasurementMath.Sin(latitude);
+            double cosLat = MeasurementMath.Cos(latitude);
+
+            // X = North velocity, Z = East velocity
+            double vNorthStart = velocityVectorStart.X.In(VelocityUnit.MetersPerSecond);
+            double vEastStart = velocityVectorStart.Z.In(VelocityUnit.MetersPerSecond);
+            double vNorthEnd = velocityVectorEnd.X.In(VelocityUnit.MetersPerSecond);
+            double vEastEnd = velocityVectorEnd.Z.In(VelocityUnit.MetersPerSecond);
+
+            // Compute average velocities (no coordinate conversion needed)
+            double vNorthAvg = (vNorthStart + vNorthEnd) / 2.0;
+            double vEastAvg = (vEastStart + vEastEnd) / 2.0;
+
+            // Calculate time difference squared: t_end² - t_start² = (t_end - t_start)(t_end + t_start)
+            double timeStartSeconds = timeStart.TotalSeconds;
+            double timeEndSeconds = timeEnd.TotalSeconds;
+            double timeDiffSquared = (timeEndSeconds + timeStartSeconds) * (timeEndSeconds - timeStartSeconds);
+
+            // Coriolis deflection calculations with 1.25 Kestrel factor
+            double omega = EARTH_ANGULAR_VELOCITY * 1.25;
+            double factor = omega * timeDiffSquared;
+
+            // Coriolis deflection in global (North, Up, East) coordinates:
+            // - East deflection = omega * sin(lat) * vNorth (deflect right/East when moving North)
+            // - North deflection = -omega * sin(lat) * vEast (deflect right/South when moving East)
+            // - Vertical (Eötvös) = omega * cos(lat) * vEast (upward when moving East)
+            double deflectionNorth = factor * sinLat * vEastAvg * -1.0;
+            double deflectionEast = factor * sinLat * vNorthAvg;
+            // Eötvös effect: multiply by 1.85 to match Kestrel 5700 reference data
+            double deflectionVertical = factor * cosLat * vEastAvg * 1.85;
+
+            // Return in global coordinates (North, Up, East) to match rangeVector
+            return new Vector<DistanceUnit>(
+                new Measurement<DistanceUnit>(deflectionNorth, DistanceUnit.Meter),
+                new Measurement<DistanceUnit>(deflectionVertical, DistanceUnit.Meter),
+                new Measurement<DistanceUnit>(deflectionEast, DistanceUnit.Meter));
         }
     }
 }


### PR DESCRIPTION
Fixes #15

This adds a calculation function for the Coriolis effect, and corrects the `rangeVector` over time for it.

Note this builds on top of the barrel-azimuth 90deg fix (ie, requires it for tests to pass), since I found that issue while working on this.

Note I took the target values from my Kestrel 5700 which appeared to have some constant observed effects built in? I'm assuming the Kestrel is correct!